### PR TITLE
[clang] add AtomicType module

### DIFF
--- a/src/clang.ml
+++ b/src/clang.ml
@@ -1395,6 +1395,18 @@ and ParenType :
   let pp fmt t = F.fprintf fmt "%a" QualType.pp (desugar t)
 end
 
+and AtomicType : 
+(Sig.ATOMIC_TYPE 
+with type t = Type.t
+and type QualType.Type.t = QualType.Type.t
+     and type QualType.t = QualType.t) = struct
+     include Type
+  module QualType = QualType
+  external get_value_type : t -> QualType.t = "clang_atomic_type_get_value_type"
+
+  let pp fmt t = F.fprintf fmt "_Atomic(%a)" QualType.pp (get_value_type t)
+end
+
 and PointerType :
   (Sig.POINTER_TYPE
     with type t = Type.t

--- a/src/clang_type.cpp
+++ b/src/clang_type.cpp
@@ -31,6 +31,13 @@ value clang_qual_type_to_string(value QT) {
   CAMLreturn(clang_to_string(qt->getAsString().c_str()));
 }
 
+value clang_atomic_type_get_value_type(value T) {
+  CAMLparam1(T);
+  LOG(__FUNCTION__);
+  clang::AtomicType *AT = *((clang::AtomicType **)Data_abstract_val(T));
+  CAMLreturn(clang_to_qual_type(AT->getValueType()));
+}
+
 WRAPPER_BOOL(clang_qual_type_is_null, QualType, isNull)
 
 WRAPPER_INT(clang_type_get_kind, Type, getTypeClass)

--- a/src/sig.ml
+++ b/src/sig.ml
@@ -705,6 +705,15 @@ module type PAREN_TYPE = sig
   val desugar : t -> QualType.t
 end
 
+module type ATOMIC_TYPE = sig
+  include NODE
+
+  module QualType : QUAL_TYPE
+
+  val get_value_type : t -> QualType.t
+
+end
+
 module type POINTER_TYPE = sig
   include NODE
 


### PR DESCRIPTION
다음과 같은 c 소스코드에서 
atomic type이 스페로우 claml frontend에서 처리가 안되어서 타입을 추가하였습니다.
```
typedef _Atomic signed char atomic_schar;
typedef _Atomic unsigned char atomic_uchar;
typedef _Atomic short atomic_short;
typedef _Atomic unsigned short atomic_ushort;
typedef _Atomic int atomic_int;
```

스페로우에서는 clamlFrontend.ml의 trans_type함수에서 clang API 함수인 
```
get_value_type : t -> QualType.t
```
를 사용하여 내부 타입(ex: signed char, short ...)을 인자로 trans_type함수를 재귀적으로 호출하도록 하였습니다.
스페로우의 수정 사항도 별도로 PR하도록 하겠습니다.