### PR TITLE
[ClangAPI] add clang::Vector functions

### DIFF
--- a/src/clang.ml
+++ b/src/clang.ml
@@ -1407,6 +1407,20 @@ and type QualType.Type.t = QualType.Type.t
   let pp fmt t = F.fprintf fmt "_Atomic(%a)" QualType.pp (get_value_type t)
 end
 
+and VectorType:
+(Sig.VECTOR_TYPE
+with type t = Type.t
+and type QualType.Type.t = QualType.Type.t
+     and type QualType.t = QualType.t) = struct
+     include Type
+  module QualType = QualType
+  external get_element_type : t -> QualType.t = "clang_vector_type_get_element_type"
+  external get_num_elements : t -> int = "clang_vector_type_get_num_elements"
+  external desugar : t -> QualType.t = "clang_vector_type_desugar"
+
+  let pp fmt t = F.fprintf fmt "%a" QualType.pp (desugar t)
+end
+
 and PointerType :
   (Sig.POINTER_TYPE
     with type t = Type.t

--- a/src/clang_type.cpp
+++ b/src/clang_type.cpp
@@ -38,6 +38,27 @@ value clang_atomic_type_get_value_type(value T) {
   CAMLreturn(clang_to_qual_type(AT->getValueType()));
 }
 
+value clang_vector_type_get_element_type(value T) {
+  CAMLparam1(T);
+  LOG(__FUNCTION__);
+  clang::VectorType *VT = *((clang::VectorType **)Data_abstract_val(T));
+  CAMLreturn(clang_to_qual_type(VT->getElementType()));
+}
+
+value clang_vector_type_get_num_elements(value T) {
+  CAMLparam1(T);
+  LOG(__FUNCTION__);
+  clang::VectorType *VT = *((clang::VectorType **)Data_abstract_val(T));
+  CAMLreturn(Val_int(VT->getNumElements()));
+}
+
+value clang_vector_type_desugar(value T) {
+  CAMLparam1(T);
+  LOG(__FUNCTION__);
+  clang::VectorType *VT = *((clang::VectorType **)Data_abstract_val(T));
+  CAMLreturn(clang_to_qual_type(VT->desugar()));
+}
+
 WRAPPER_BOOL(clang_qual_type_is_null, QualType, isNull)
 
 WRAPPER_INT(clang_type_get_kind, Type, getTypeClass)

--- a/src/sig.ml
+++ b/src/sig.ml
@@ -714,6 +714,18 @@ module type ATOMIC_TYPE = sig
 
 end
 
+module type VECTOR_TYPE = sig
+  include NODE
+
+  module QualType : QUAL_TYPE
+
+  val get_element_type : t -> QualType.t
+
+  val get_num_elements : t -> int
+  
+  val desugar : t -> QualType.t
+end
+
 module type POINTER_TYPE = sig
   include NODE
 


### PR DESCRIPTION
Vector타입의 함수들을 추가하였습니다.
https://github.com/prosyslab/sparrow-incubator/issues/66