### PR TITLE
Rewriter API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ src/declKind.ml
 src/attrKind.ml
 src/implicitCastKind.ml
 config
+
+.vscode
+rewriter-test-runner

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 all:
 	dune build src
 	dune build test/test.exe
+	dune build test/rewriter/test.exe
 	ln -sf _build/default/test/test.exe test-runner
+	ln -sf _build/default/test/rewriter/test.exe rewriter-test-runner
 
 test: all
 	dune test

--- a/src/clang.ml
+++ b/src/clang.ml
@@ -15,6 +15,8 @@ end
 
 let ast_context : ASTContext.t ref option = None
 
+
+(** OCaml record representation of [clang::PresumedLoc]  *)
 module SourceLocation : Sig.SOURCE_LOCATION = struct
   type t = { filename : string; line : int; column : int }
 end
@@ -1528,12 +1530,27 @@ and QualType : (Sig.QUAL_TYPE with type Type.t = Type.t) = struct
     F.fprintf fmt "%a" Type.pp ty
 end
 
+module Rewriter = struct
+  type t
+
+  (** Returns true if it did nothing *)
+  external insert_before_decl : Decl.t -> string -> t -> bool =
+    "clang_rewriter_insert_before_decl"
+
+  external insert_before_stmt : Stmt.t -> string -> t -> bool =
+    "clang_rewriter_insert_before_stmt"
+  
+  external emit_string : t -> string = "clang_rewriter_emit_string"
+end
+
 module TranslationUnit = struct
   type t
 
   type ast
 
   external parse_file_internal : string array -> ast = "clang_parse_file"
+
+  external get_rewriter : ast -> Rewriter.t = "clang_get_rewriter"
 
   external get_translation_unit : ast -> t = "clang_get_translation_unit"
 

--- a/src/clang_ocaml.cpp
+++ b/src/clang_ocaml.cpp
@@ -98,17 +98,14 @@ clang::ASTUnit *parse_internal(int argc, char const **argv) {
   Diags->setSuppressAllDiagnostics(true);
   clang::FileSystemOptions FileSystemOpts;
   llvm::SmallVector<const char *, 4> Args;
+  Args.push_back("clang");
+  Args.push_back("-cc1");
   Args.push_back("-fsyntax-only");
   Args.push_back(argv[0]);
   std::shared_ptr<clang::PCHContainerOperations> PCHContainerOps =
       std::make_shared<clang::PCHContainerOperations>();
-
-  std::shared_ptr<clang::CompilerInvocation> CI = std::make_shared<clang::CompilerInvocation>();
-  if (!clang::CompilerInvocation::CreateFromArgs(*CI, Args, *Diags)) {
-    return nullptr;
-  }
-  clang::ASTUnit *Unit =
-    clang::ASTUnit::LoadFromCompilerInvocationAction(CI, PCHContainerOps, Diags);
+  clang::ASTUnit *Unit(clang::ASTUnit::LoadFromCommandLine(
+    Args.data(), Args.data() + Args.size(), PCHContainerOps, Diags, ""));
   
   clang::SourceManager &SM = Unit->getSourceManager();
   assert (&SM != nullptr);

--- a/test/dune
+++ b/test/dune
@@ -5,8 +5,8 @@
  (libraries claml))
  
 (rule
- (deps alignof0.c)
- (targets alignof0.output)
+ (deps usertype-in-local2.c)
+ (targets usertype-in-local2.output)
  (action
   (with-stdout-to
    %{targets}
@@ -18,263 +18,7 @@
 (rule
  (alias runtest)
  (action
-  (diff alignof0.expected alignof0.output)))
-
-(rule
- (deps anonymous-struct0.c)
- (targets anonymous-struct0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff anonymous-struct0.expected anonymous-struct0.output)))
-
-(rule
- (deps anonymous-struct1.c)
- (targets anonymous-struct1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff anonymous-struct1.expected anonymous-struct1.output)))
-
-(rule
- (deps anonymous-struct2.c)
- (targets anonymous-struct2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff anonymous-struct2.expected anonymous-struct2.output)))
-
-(rule
- (deps array-init0.c)
- (targets array-init0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff array-init0.expected array-init0.output)))
-
-(rule
- (deps array-subscript0.c)
- (targets array-subscript0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff array-subscript0.expected array-subscript0.output)))
-
-(rule
- (deps array-subscript1.c)
- (targets array-subscript1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff array-subscript1.expected array-subscript1.output)))
-
-(rule
- (deps array-subscript2.c)
- (targets array-subscript2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff array-subscript2.expected array-subscript2.output)))
-
-(rule
- (deps attribute0.c)
- (targets attribute0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff attribute0.expected attribute0.output)))
-
-(rule
- (deps attribute1.c)
- (targets attribute1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff attribute1.expected attribute1.output)))
-
-(rule
- (deps attr-stmt0.c)
- (targets attr-stmt0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff attr-stmt0.expected attr-stmt0.output)))
-
-(rule
- (deps binary_operator.c)
- (targets binary_operator.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff binary_operator.expected binary_operator.output)))
-
-(rule
- (deps binop0.c)
- (targets binop0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff binop0.expected binop0.output)))
-
-(rule
- (deps block0.c)
- (targets block0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff block0.expected block0.output)))
-
-(rule
- (deps cast0.c)
- (targets cast0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff cast0.expected cast0.output)))
-
-(rule
- (deps cast1.c)
- (targets cast1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff cast1.expected cast1.output)))
-
-(rule
- (deps comma0.c)
- (targets comma0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff comma0.expected comma0.output)))
+  (diff usertype-in-local2.expected usertype-in-local2.output)))
 
 (rule
  (deps comma1.c)
@@ -293,22 +37,6 @@
   (diff comma1.expected comma1.output)))
 
 (rule
- (deps designated-init0.c)
- (targets designated-init0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff designated-init0.expected designated-init0.output)))
-
-(rule
  (deps designated-init1.c)
  (targets designated-init1.output)
  (action
@@ -325,8 +53,8 @@
   (diff designated-init1.expected designated-init1.output)))
 
 (rule
- (deps duplicated-label0.c)
- (targets duplicated-label0.output)
+ (deps variable-array0.c)
+ (targets variable-array0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -338,11 +66,11 @@
 (rule
  (alias runtest)
  (action
-  (diff duplicated-label0.expected duplicated-label0.output)))
+  (diff variable-array0.expected variable-array0.output)))
 
 (rule
- (deps duplication0.c)
- (targets duplication0.output)
+ (deps nested-init2.c)
+ (targets nested-init2.output)
  (action
   (with-stdout-to
    %{targets}
@@ -354,11 +82,11 @@
 (rule
  (alias runtest)
  (action
-  (diff duplication0.expected duplication0.output)))
+  (diff nested-init2.expected nested-init2.output)))
 
 (rule
- (deps enum0.c)
- (targets enum0.output)
+ (deps indirect-field3.c)
+ (targets indirect-field3.output)
  (action
   (with-stdout-to
    %{targets}
@@ -370,11 +98,11 @@
 (rule
  (alias runtest)
  (action
-  (diff enum0.expected enum0.output)))
+  (diff indirect-field3.expected indirect-field3.output)))
 
 (rule
- (deps enum1.c)
- (targets enum1.output)
+ (deps param0.c)
+ (targets param0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -386,71 +114,7 @@
 (rule
  (alias runtest)
  (action
-  (diff enum1.expected enum1.output)))
-
-(rule
- (deps enum2.c)
- (targets enum2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff enum2.expected enum2.output)))
-
-(rule
- (deps function0.c)
- (targets function0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff function0.expected function0.output)))
-
-(rule
- (deps global-array0.c)
- (targets global-array0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff global-array0.expected global-array0.output)))
-
-(rule
- (deps goto0.c)
- (targets goto0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff goto0.expected goto0.output)))
+  (diff param0.expected param0.output)))
 
 (rule
  (deps goto1.c)
@@ -469,8 +133,8 @@
   (diff goto1.expected goto1.output)))
 
 (rule
- (deps goto2.c)
- (targets goto2.output)
+ (deps __uint128_t0.c)
+ (targets __uint128_t0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -482,11 +146,11 @@
 (rule
  (alias runtest)
  (action
-  (diff goto2.expected goto2.output)))
+  (diff __uint128_t0.expected __uint128_t0.output)))
 
 (rule
- (deps goto3.c)
- (targets goto3.output)
+ (deps self-reference-array.c)
+ (targets self-reference-array.output)
  (action
   (with-stdout-to
    %{targets}
@@ -498,11 +162,11 @@
 (rule
  (alias runtest)
  (action
-  (diff goto3.expected goto3.output)))
+  (diff self-reference-array.expected self-reference-array.output)))
 
 (rule
- (deps if0.c)
- (targets if0.output)
+ (deps struct6.c)
+ (targets struct6.output)
  (action
   (with-stdout-to
    %{targets}
@@ -514,11 +178,11 @@
 (rule
  (alias runtest)
  (action
-  (diff if0.expected if0.output)))
+  (diff struct6.expected struct6.output)))
 
 (rule
- (deps if1.c)
- (targets if1.output)
+ (deps goto0.c)
+ (targets goto0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -530,7 +194,151 @@
 (rule
  (alias runtest)
  (action
-  (diff if1.expected if1.output)))
+  (diff goto0.expected goto0.output)))
+
+(rule
+ (deps local-init9.c)
+ (targets local-init9.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init9.expected local-init9.output)))
+
+(rule
+ (deps struct1.c)
+ (targets struct1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff struct1.expected struct1.output)))
+
+(rule
+ (deps predef-macro.c)
+ (targets predef-macro.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff predef-macro.expected predef-macro.output)))
+
+(rule
+ (deps local-fun0.c)
+ (targets local-fun0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-fun0.expected local-fun0.output)))
+
+(rule
+ (deps pointer2.c)
+ (targets pointer2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff pointer2.expected pointer2.output)))
+
+(rule
+ (deps cast0.c)
+ (targets cast0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff cast0.expected cast0.output)))
+
+(rule
+ (deps ternop3.c)
+ (targets ternop3.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff ternop3.expected ternop3.output)))
+
+(rule
+ (deps local-init3.c)
+ (targets local-init3.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init3.expected local-init3.output)))
+
+(rule
+ (deps unicode0.c)
+ (targets unicode0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff unicode0.expected unicode0.output)))
 
 (rule
  (deps if2.c)
@@ -549,6 +357,390 @@
   (diff if2.expected if2.output)))
 
 (rule
+ (deps switch0.c)
+ (targets switch0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff switch0.expected switch0.output)))
+
+(rule
+ (deps array-subscript0.c)
+ (targets array-subscript0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff array-subscript0.expected array-subscript0.output)))
+
+(rule
+ (deps struct3.c)
+ (targets struct3.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff struct3.expected struct3.output)))
+
+(rule
+ (deps array-init0.c)
+ (targets array-init0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff array-init0.expected array-init0.output)))
+
+(rule
+ (deps local-init4.c)
+ (targets local-init4.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init4.expected local-init4.output)))
+
+(rule
+ (deps implicit-cast4.c)
+ (targets implicit-cast4.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff implicit-cast4.expected implicit-cast4.output)))
+
+(rule
+ (deps local-init1.c)
+ (targets local-init1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init1.expected local-init1.output)))
+
+(rule
+ (deps local-init7.c)
+ (targets local-init7.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init7.expected local-init7.output)))
+
+(rule
+ (deps global-array0.c)
+ (targets global-array0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff global-array0.expected global-array0.output)))
+
+(rule
+ (deps missing-proto0.c)
+ (targets missing-proto0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff missing-proto0.expected missing-proto0.output)))
+
+(rule
+ (deps block0.c)
+ (targets block0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff block0.expected block0.output)))
+
+(rule
+ (deps stmt0.c)
+ (targets stmt0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff stmt0.expected stmt0.output)))
+
+(rule
+ (deps pointer0.c)
+ (targets pointer0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff pointer0.expected pointer0.output)))
+
+(rule
+ (deps pointer4.c)
+ (targets pointer4.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff pointer4.expected pointer4.output)))
+
+(rule
+ (deps function0.c)
+ (targets function0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff function0.expected function0.output)))
+
+(rule
+ (deps enum1.c)
+ (targets enum1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff enum1.expected enum1.output)))
+
+(rule
+ (deps enum0.c)
+ (targets enum0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff enum0.expected enum0.output)))
+
+(rule
+ (deps pointer1.c)
+ (targets pointer1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff pointer1.expected pointer1.output)))
+
+(rule
+ (deps label2.c)
+ (targets label2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff label2.expected label2.output)))
+
+(rule
+ (deps struct0.c)
+ (targets struct0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff struct0.expected struct0.output)))
+
+(rule
+ (deps comma0.c)
+ (targets comma0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff comma0.expected comma0.output)))
+
+(rule
+ (deps designated-init0.c)
+ (targets designated-init0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff designated-init0.expected designated-init0.output)))
+
+(rule
+ (deps indirect-field1.c)
+ (targets indirect-field1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff indirect-field1.expected indirect-field1.output)))
+
+(rule
+ (deps array-subscript1.c)
+ (targets array-subscript1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff array-subscript1.expected array-subscript1.output)))
+
+(rule
  (deps if3.c)
  (targets if3.output)
  (action
@@ -563,6 +755,902 @@
  (alias runtest)
  (action
   (diff if3.expected if3.output)))
+
+(rule
+ (deps goto3.c)
+ (targets goto3.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff goto3.expected goto3.output)))
+
+(rule
+ (deps cast1.c)
+ (targets cast1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff cast1.expected cast1.output)))
+
+(rule
+ (deps duplication0.c)
+ (targets duplication0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff duplication0.expected duplication0.output)))
+
+(rule
+ (deps label0.c)
+ (targets label0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff label0.expected label0.output)))
+
+(rule
+ (deps usertype-in-local0.c)
+ (targets usertype-in-local0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff usertype-in-local0.expected usertype-in-local0.output)))
+
+(rule
+ (deps implicit-cast3.c)
+ (targets implicit-cast3.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff implicit-cast3.expected implicit-cast3.output)))
+
+(rule
+ (deps long0.c)
+ (targets long0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff long0.expected long0.output)))
+
+(rule
+ (deps type2.c)
+ (targets type2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff type2.expected type2.output)))
+
+(rule
+ (deps ternop1.c)
+ (targets ternop1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff ternop1.expected ternop1.output)))
+
+(rule
+ (deps while2.c)
+ (targets while2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff while2.expected while2.output)))
+
+(rule
+ (deps vaarg0.c)
+ (targets vaarg0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff vaarg0.expected vaarg0.output)))
+
+(rule
+ (deps init-list0.c)
+ (targets init-list0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff init-list0.expected init-list0.output)))
+
+(rule
+ (deps return1.c)
+ (targets return1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff return1.expected return1.output)))
+
+(rule
+ (deps binary_operator.c)
+ (targets binary_operator.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff binary_operator.expected binary_operator.output)))
+
+(rule
+ (deps label1.c)
+ (targets label1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff label1.expected label1.output)))
+
+(rule
+ (deps usertype-in-local3.c)
+ (targets usertype-in-local3.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff usertype-in-local3.expected usertype-in-local3.output)))
+
+(rule
+ (deps decl0.c)
+ (targets decl0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff decl0.expected decl0.output)))
+
+(rule
+ (deps while0.c)
+ (targets while0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff while0.expected while0.output)))
+
+(rule
+ (deps incomplete-array0.c)
+ (targets incomplete-array0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff incomplete-array0.expected incomplete-array0.output)))
+
+(rule
+ (deps unary_operator0.c)
+ (targets unary_operator0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff unary_operator0.expected unary_operator0.output)))
+
+(rule
+ (deps local-init6.c)
+ (targets local-init6.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init6.expected local-init6.output)))
+
+(rule
+ (deps if0.c)
+ (targets if0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff if0.expected if0.output)))
+
+(rule
+ (deps usertype-in-local1.c)
+ (targets usertype-in-local1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff usertype-in-local1.expected usertype-in-local1.output)))
+
+(rule
+ (deps local-init5.c)
+ (targets local-init5.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init5.expected local-init5.output)))
+
+(rule
+ (deps unexposed.c)
+ (targets unexposed.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff unexposed.expected unexposed.output)))
+
+(rule
+ (deps type0.c)
+ (targets type0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff type0.expected type0.output)))
+
+(rule
+ (deps struct2.c)
+ (targets struct2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff struct2.expected struct2.output)))
+
+(rule
+ (deps implicit-cast2.c)
+ (targets implicit-cast2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff implicit-cast2.expected implicit-cast2.output)))
+
+(rule
+ (deps ternop2.c)
+ (targets ternop2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff ternop2.expected ternop2.output)))
+
+(rule
+ (deps duplicated-label0.c)
+ (targets duplicated-label0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff duplicated-label0.expected duplicated-label0.output)))
+
+(rule
+ (deps struct7.c)
+ (targets struct7.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff struct7.expected struct7.output)))
+
+(rule
+ (deps goto2.c)
+ (targets goto2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff goto2.expected goto2.output)))
+
+(rule
+ (deps nested-init0.c)
+ (targets nested-init0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff nested-init0.expected nested-init0.output)))
+
+(rule
+ (deps attribute0.c)
+ (targets attribute0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff attribute0.expected attribute0.output)))
+
+(rule
+ (deps pointer6.c)
+ (targets pointer6.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff pointer6.expected pointer6.output)))
+
+(rule
+ (deps local-init8.c)
+ (targets local-init8.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init8.expected local-init8.output)))
+
+(rule
+ (deps switch1.c)
+ (targets switch1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff switch1.expected switch1.output)))
+
+(rule
+ (deps local-init10.c)
+ (targets local-init10.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init10.expected local-init10.output)))
+
+(rule
+ (deps attribute1.c)
+ (targets attribute1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff attribute1.expected attribute1.output)))
+
+(rule
+ (deps return0.c)
+ (targets return0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff return0.expected return0.output)))
+
+(rule
+ (deps ternop0.c)
+ (targets ternop0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff ternop0.expected ternop0.output)))
+
+(rule
+ (deps namespace0.c)
+ (targets namespace0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff namespace0.expected namespace0.output)))
+
+(rule
+ (deps long1.c)
+ (targets long1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff long1.expected long1.output)))
+
+(rule
+ (deps local-init2.c)
+ (targets local-init2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-init2.expected local-init2.output)))
+
+(rule
+ (deps return2.c)
+ (targets return2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff return2.expected return2.output)))
+
+(rule
+ (deps init-list1.c)
+ (targets init-list1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff init-list1.expected init-list1.output)))
+
+(rule
+ (deps anonymous-struct0.c)
+ (targets anonymous-struct0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff anonymous-struct0.expected anonymous-struct0.output)))
+
+(rule
+ (deps struct5.c)
+ (targets struct5.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff struct5.expected struct5.output)))
+
+(rule
+ (deps enum2.c)
+ (targets enum2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff enum2.expected enum2.output)))
+
+(rule
+ (deps variable-array1.c)
+ (targets variable-array1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff variable-array1.expected variable-array1.output)))
+
+(rule
+ (deps indirect-field2.c)
+ (targets indirect-field2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff indirect-field2.expected indirect-field2.output)))
+
+(rule
+ (deps array-subscript2.c)
+ (targets array-subscript2.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff array-subscript2.expected array-subscript2.output)))
+
+(rule
+ (deps stmtexpr0.c)
+ (targets stmtexpr0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff stmtexpr0.expected stmtexpr0.output)))
+
+(rule
+ (deps local-array0.c)
+ (targets local-array0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff local-array0.expected local-array0.output)))
+
+(rule
+ (deps type1.c)
+ (targets type1.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff type1.expected type1.output)))
+
+(rule
+ (deps static0.c)
+ (targets static0.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff static0.expected static0.output)))
 
 (rule
  (deps implicit-cast0.c)
@@ -597,8 +1685,8 @@
   (diff implicit-cast1.expected implicit-cast1.output)))
 
 (rule
- (deps implicit-cast2.c)
- (targets implicit-cast2.output)
+ (deps attr-stmt0.c)
+ (targets attr-stmt0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -610,11 +1698,11 @@
 (rule
  (alias runtest)
  (action
-  (diff implicit-cast2.expected implicit-cast2.output)))
+  (diff attr-stmt0.expected attr-stmt0.output)))
 
 (rule
- (deps implicit-cast3.c)
- (targets implicit-cast3.output)
+ (deps binop0.c)
+ (targets binop0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -626,11 +1714,11 @@
 (rule
  (alias runtest)
  (action
-  (diff implicit-cast3.expected implicit-cast3.output)))
+  (diff binop0.expected binop0.output)))
 
 (rule
- (deps implicit-cast4.c)
- (targets implicit-cast4.output)
+ (deps compound-literal0.c)
+ (targets compound-literal0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -642,999 +1730,7 @@
 (rule
  (alias runtest)
  (action
-  (diff implicit-cast4.expected implicit-cast4.output)))
-
-(rule
- (deps incomplete-array0.c)
- (targets incomplete-array0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff incomplete-array0.expected incomplete-array0.output)))
-
-(rule
- (deps indirect-field0.c)
- (targets indirect-field0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff indirect-field0.expected indirect-field0.output)))
-
-(rule
- (deps indirect-field1.c)
- (targets indirect-field1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff indirect-field1.expected indirect-field1.output)))
-
-(rule
- (deps indirect-field2.c)
- (targets indirect-field2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff indirect-field2.expected indirect-field2.output)))
-
-(rule
- (deps indirect-field3.c)
- (targets indirect-field3.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff indirect-field3.expected indirect-field3.output)))
-
-(rule
- (deps init-list0.c)
- (targets init-list0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff init-list0.expected init-list0.output)))
-
-(rule
- (deps init-list1.c)
- (targets init-list1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff init-list1.expected init-list1.output)))
-
-(rule
- (deps __int128_t0.c)
- (targets __int128_t0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff __int128_t0.expected __int128_t0.output)))
-
-(rule
- (deps label0.c)
- (targets label0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff label0.expected label0.output)))
-
-(rule
- (deps label1.c)
- (targets label1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff label1.expected label1.output)))
-
-(rule
- (deps label2.c)
- (targets label2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff label2.expected label2.output)))
-
-(rule
- (deps local-array0.c)
- (targets local-array0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-array0.expected local-array0.output)))
-
-(rule
- (deps local-fun0.c)
- (targets local-fun0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-fun0.expected local-fun0.output)))
-
-(rule
- (deps local-init10.c)
- (targets local-init10.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init10.expected local-init10.output)))
-
-(rule
- (deps local-init1.c)
- (targets local-init1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init1.expected local-init1.output)))
-
-(rule
- (deps local-init2.c)
- (targets local-init2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init2.expected local-init2.output)))
-
-(rule
- (deps local-init3.c)
- (targets local-init3.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init3.expected local-init3.output)))
-
-(rule
- (deps local-init4.c)
- (targets local-init4.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init4.expected local-init4.output)))
-
-(rule
- (deps local-init5.c)
- (targets local-init5.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init5.expected local-init5.output)))
-
-(rule
- (deps local-init6.c)
- (targets local-init6.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init6.expected local-init6.output)))
-
-(rule
- (deps local-init7.c)
- (targets local-init7.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init7.expected local-init7.output)))
-
-(rule
- (deps local-init8.c)
- (targets local-init8.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init8.expected local-init8.output)))
-
-(rule
- (deps local-init9.c)
- (targets local-init9.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff local-init9.expected local-init9.output)))
-
-(rule
- (deps long0.c)
- (targets long0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff long0.expected long0.output)))
-
-(rule
- (deps long1.c)
- (targets long1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff long1.expected long1.output)))
-
-(rule
- (deps missing-proto0.c)
- (targets missing-proto0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff missing-proto0.expected missing-proto0.output)))
-
-(rule
- (deps namespace0.c)
- (targets namespace0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff namespace0.expected namespace0.output)))
-
-(rule
- (deps nested-init1.c)
- (targets nested-init1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff nested-init1.expected nested-init1.output)))
-
-(rule
- (deps nested-init2.c)
- (targets nested-init2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff nested-init2.expected nested-init2.output)))
-
-(rule
- (deps param0.c)
- (targets param0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff param0.expected param0.output)))
-
-(rule
- (deps pointer0.c)
- (targets pointer0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff pointer0.expected pointer0.output)))
-
-(rule
- (deps pointer1.c)
- (targets pointer1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff pointer1.expected pointer1.output)))
-
-(rule
- (deps pointer2.c)
- (targets pointer2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff pointer2.expected pointer2.output)))
-
-(rule
- (deps pointer3.c)
- (targets pointer3.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff pointer3.expected pointer3.output)))
-
-(rule
- (deps pointer4.c)
- (targets pointer4.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff pointer4.expected pointer4.output)))
-
-(rule
- (deps pointer5.c)
- (targets pointer5.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff pointer5.expected pointer5.output)))
-
-(rule
- (deps pointer6.c)
- (targets pointer6.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff pointer6.expected pointer6.output)))
-
-(rule
- (deps predef-macro.c)
- (targets predef-macro.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff predef-macro.expected predef-macro.output)))
-
-(rule
- (deps return0.c)
- (targets return0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff return0.expected return0.output)))
-
-(rule
- (deps return1.c)
- (targets return1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff return1.expected return1.output)))
-
-(rule
- (deps return2.c)
- (targets return2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff return2.expected return2.output)))
-
-(rule
- (deps self-reference-array.c)
- (targets self-reference-array.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff self-reference-array.expected self-reference-array.output)))
-
-(rule
- (deps static0.c)
- (targets static0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff static0.expected static0.output)))
-
-(rule
- (deps stmtexpr0.c)
- (targets stmtexpr0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff stmtexpr0.expected stmtexpr0.output)))
-
-(rule
- (deps struct0.c)
- (targets struct0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct0.expected struct0.output)))
-
-(rule
- (deps struct1.c)
- (targets struct1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct1.expected struct1.output)))
-
-(rule
- (deps struct2.c)
- (targets struct2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct2.expected struct2.output)))
-
-(rule
- (deps struct3.c)
- (targets struct3.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct3.expected struct3.output)))
-
-(rule
- (deps struct4.c)
- (targets struct4.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct4.expected struct4.output)))
-
-(rule
- (deps struct5.c)
- (targets struct5.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct5.expected struct5.output)))
-
-(rule
- (deps struct6.c)
- (targets struct6.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct6.expected struct6.output)))
-
-(rule
- (deps struct7.c)
- (targets struct7.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff struct7.expected struct7.output)))
-
-(rule
- (deps switch0.c)
- (targets switch0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff switch0.expected switch0.output)))
-
-(rule
- (deps switch1.c)
- (targets switch1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff switch1.expected switch1.output)))
-
-(rule
- (deps ternop0.c)
- (targets ternop0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff ternop0.expected ternop0.output)))
-
-(rule
- (deps ternop1.c)
- (targets ternop1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff ternop1.expected ternop1.output)))
-
-(rule
- (deps ternop2.c)
- (targets ternop2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff ternop2.expected ternop2.output)))
-
-(rule
- (deps ternop3.c)
- (targets ternop3.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff ternop3.expected ternop3.output)))
-
-(rule
- (deps type0.c)
- (targets type0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff type0.expected type0.output)))
-
-(rule
- (deps type1.c)
- (targets type1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff type1.expected type1.output)))
-
-(rule
- (deps type2.c)
- (targets type2.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff type2.expected type2.output)))
-
-(rule
- (deps __uint128_t0.c)
- (targets __uint128_t0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff __uint128_t0.expected __uint128_t0.output)))
+  (diff compound-literal0.expected compound-literal0.output)))
 
 (rule
  (deps UL0.c)
@@ -1653,8 +1749,8 @@
   (diff UL0.expected UL0.output)))
 
 (rule
- (deps unary_operator0.c)
- (targets unary_operator0.output)
+ (deps if1.c)
+ (targets if1.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1666,11 +1762,11 @@
 (rule
  (alias runtest)
  (action
-  (diff unary_operator0.expected unary_operator0.output)))
+  (diff if1.expected if1.output)))
 
 (rule
- (deps unexposed.c)
- (targets unexposed.output)
+ (deps anonymous-struct2.c)
+ (targets anonymous-struct2.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1682,11 +1778,11 @@
 (rule
  (alias runtest)
  (action
-  (diff unexposed.expected unexposed.output)))
+  (diff anonymous-struct2.expected anonymous-struct2.output)))
 
 (rule
- (deps unicode0.c)
- (targets unicode0.output)
+ (deps pointer5.c)
+ (targets pointer5.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1698,11 +1794,11 @@
 (rule
  (alias runtest)
  (action
-  (diff unicode0.expected unicode0.output)))
+  (diff pointer5.expected pointer5.output)))
 
 (rule
- (deps usertype-in-local0.c)
- (targets usertype-in-local0.output)
+ (deps anonymous-struct1.c)
+ (targets anonymous-struct1.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1714,11 +1810,11 @@
 (rule
  (alias runtest)
  (action
-  (diff usertype-in-local0.expected usertype-in-local0.output)))
+  (diff anonymous-struct1.expected anonymous-struct1.output)))
 
 (rule
- (deps usertype-in-local1.c)
- (targets usertype-in-local1.output)
+ (deps nested-init1.c)
+ (targets nested-init1.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1730,11 +1826,11 @@
 (rule
  (alias runtest)
  (action
-  (diff usertype-in-local1.expected usertype-in-local1.output)))
+  (diff nested-init1.expected nested-init1.output)))
 
 (rule
- (deps usertype-in-local2.c)
- (targets usertype-in-local2.output)
+ (deps pointer3.c)
+ (targets pointer3.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1746,87 +1842,7 @@
 (rule
  (alias runtest)
  (action
-  (diff usertype-in-local2.expected usertype-in-local2.output)))
-
-(rule
- (deps usertype-in-local3.c)
- (targets usertype-in-local3.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff usertype-in-local3.expected usertype-in-local3.output)))
-
-(rule
- (deps vaarg0.c)
- (targets vaarg0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff vaarg0.expected vaarg0.output)))
-
-(rule
- (deps variable-array0.c)
- (targets variable-array0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff variable-array0.expected variable-array0.output)))
-
-(rule
- (deps variable-array1.c)
- (targets variable-array1.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff variable-array1.expected variable-array1.output)))
-
-(rule
- (deps while0.c)
- (targets while0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff while0.expected while0.output)))
+  (diff pointer3.expected pointer3.output)))
 
 (rule
  (deps while1.c)
@@ -1845,8 +1861,8 @@
   (diff while1.expected while1.output)))
 
 (rule
- (deps while2.c)
- (targets while2.output)
+ (deps alignof0.c)
+ (targets alignof0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1858,11 +1874,11 @@
 (rule
  (alias runtest)
  (action
-  (diff while2.expected while2.output)))
+  (diff alignof0.expected alignof0.output)))
 
 (rule
- (deps decl0.c)
- (targets decl0.output)
+ (deps struct4.c)
+ (targets struct4.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1874,11 +1890,11 @@
 (rule
  (alias runtest)
  (action
-  (diff decl0.expected decl0.output)))
+  (diff struct4.expected struct4.output)))
 
 (rule
- (deps stmt0.c)
- (targets stmt0.output)
+ (deps indirect-field0.c)
+ (targets indirect-field0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1890,11 +1906,11 @@
 (rule
  (alias runtest)
  (action
-  (diff stmt0.expected stmt0.output)))
+  (diff indirect-field0.expected indirect-field0.output)))
 
 (rule
- (deps nested-init0.c)
- (targets nested-init0.output)
+ (deps __int128_t0.c)
+ (targets __int128_t0.output)
  (action
   (with-stdout-to
    %{targets}
@@ -1906,21 +1922,5 @@
 (rule
  (alias runtest)
  (action
-  (diff nested-init0.expected nested-init0.output)))
-
-(rule
- (deps compound-literal0.c)
- (targets compound-literal0.output)
- (action
-  (with-stdout-to
-   %{targets}
-   (pipe-stdout
-    (ignore-stderr
-     (run ./test.exe %{deps}))
-    (run clang-format)))))
-
-(rule
- (alias runtest)
- (action
-  (diff compound-literal0.expected compound-literal0.output)))
+  (diff __int128_t0.expected __int128_t0.output)))
 

--- a/test/rewriter/dune
+++ b/test/rewriter/dune
@@ -1,0 +1,20 @@
+(executable
+ (name test)
+ (modules test)
+ (flags -runtime-variant d -g)
+ (libraries claml))
+
+(rule
+ (deps simple.c)
+ (targets simple.output)
+ (action
+  (with-stdout-to
+   %{targets}
+   (pipe-stdout
+    (ignore-stderr
+     (run ./test.exe %{deps}))
+    (run clang-format)))))
+
+(rule
+ (alias runtest)
+ (action (diff simple.output simple.expected)))

--- a/test/rewriter/simple.c
+++ b/test/rewriter/simple.c
@@ -1,0 +1,3 @@
+int f(int x) {
+    return x + 1;
+}

--- a/test/rewriter/simple.expected
+++ b/test/rewriter/simple.expected
@@ -1,0 +1,2 @@
+/* inserted */
+int f(int x) { return x + 1; }

--- a/test/rewriter/test.ml
+++ b/test/rewriter/test.ml
@@ -1,0 +1,31 @@
+open Claml
+
+module F = Format
+
+let () =
+  let _ = Clang.initialize () in
+  let ast =
+    Clang.TranslationUnit.parse_file_internal [| Sys.argv.(1) |]
+  in
+  let tu = Clang.TranslationUnit.get_translation_unit ast in
+  let rw = Clang.TranslationUnit.get_rewriter ast in
+
+  let rec insert_comment decl =
+    match decl with
+    | None -> ()
+    | Some decl ->
+    (match Clang.Decl.get_kind decl with
+    | Clang.DeclKind.FunctionDecl  ->
+      let _ = Clang.Rewriter.insert_before_decl decl "/* inserted */\n" rw in
+      ()
+    | _ ->
+      let next = Clang.TranslationUnit.decls_succ decl in
+      insert_comment next) in
+  
+  insert_comment (Clang.TranslationUnit.decls_begin tu);
+
+  Clang.Rewriter.emit_string rw
+  |> print_endline;
+  
+  ()
+  


### PR DESCRIPTION
### Overview
- `Clang` 모듈에 `Rewriter` 모듈을 추가하였습니다.
- `Rewriter` 모듈은 현재 `insert_before_decl`, `insert_before_stmt`, `emit_string` 함수를 지원합니다. 비슷한 방식으로 `insert_after_...` 함수를 작성할 수 있습니다.
- `Rewriter.t` 값은 `TranslationUnit.ast` 값으로 부터 생성할 수 있습니다.
- 재작성 결과는 `emit_string` 으로 사용할 수 있습니다.
- 간단한 테스트 프로그램을 `test/rewriter/`에 작성하고 테스크 케이스에 대해 작동함을 확인하였습니다. `make test`로 재현할 수 있습니다.

---

### 추가로 고려해야 해보면 좋은 사항

1. Rewriter 메모리 관리를 어떻게 할 것인가? (심각한 문제 없으면 무시 가능)
2. 현재 `SourceLocation`이 OCaml Record로 관리되어 이 값을 Clang C++ API에서 사용하기 힘듦. `Rewriter` 함수가 `insert_before`가 아니라 `insert_before_decl`, `insert_before_stmt`로 구현된 이유이기도 함. Clang C++ API 측에서 Decl과 Stmt의 `SourceLocation`를 가져와 바로 사용하고 있음.